### PR TITLE
Add branca 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ about:
   description: |
     This library is a spinoff from folium with the non-map-specific features.
     It can be used to generate HTML + JS. It is based on Jinja2.
-  doc_url: https://branca.readthedocs.io/
+  doc_url: https://python-visualization.github.io/branca/
   dev_url: https://github.com/python-visualization/branca
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,41 +1,49 @@
-{% set version = "0.4.2" %}
+{% set name = "branca" %}
+{% set version = "0.6.0" %}
 
 package:
-  name: branca
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/b/branca/branca-{{ version }}.tar.gz
-  sha256: c111453617b17ab2bda60a4cd71787d6f2b59c85cdf71ab160a737606ac66c31
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/branca-{{ version }}.tar.gz
+  sha256: 55949855214504c7583b71b9a03a84dce2e96a84027613bb53b42d04844ce24e
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - python >=3
+    - python
     - pip
-  run:
-    - python >=3
     - setuptools
+    - setuptools_scm
+    - wheel
+  run:
+    - python
     - jinja2
-    - six
 
 test:
+  imports:
+    - branca
   requires:
     - pip
   commands:
     - pip check
-  imports:
-    - branca
 
 about:
   home: https://github.com/python-visualization/branca
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
   summary: This library is a spinoff from folium with the non-map-specific features
+  description: |
+    This library is a spinoff from folium with the non-map-specific features.
+    It can be used to generate HTML + JS. It is based on Jinja2.
+  doc_url: https://branca.readthedocs.io/
+  dev_url: https://github.com/python-visualization/branca
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`folium` requires it https://github.com/AnacondaRecipes/folium-feedstock/pull/3

Changelog: https://github.com/python-visualization/branca/blob/v0.6.0/CHANGES.txt
License: https://github.com/python-visualization/branca/blob/v0.6.0/LICENSE.txt
Requirements:
- https://github.com/python-visualization/branca/blob/v0.6.0/pyproject.toml
- https://github.com/python-visualization/branca/blob/v0.6.0/requirements.txt
- https://github.com/python-visualization/branca/blob/v0.6.0/setup.py

Actions:

- Skip `py<37`

- Add -`-no-deps` to `script`

- Add missing `setuptools_scm` and `wheel`

- Fix `python` in `host` and `run`

- Remove `setuptools` from `run`

- Add `license_family`

- Add `description`

- Add dev and doc urls